### PR TITLE
Add `effective_batch_size` Parameter for Gradient Accumulation Support

### DIFF
--- a/gpu/slm.c
+++ b/gpu/slm.c
@@ -285,7 +285,7 @@ void update_weights_slm(SLM* slm, float learning_rate, int effective_batch_size)
     adamw_update_kernel_slm<<<token_blocks, block_size>>>(
         slm->d_token_embedding, slm->d_token_embedding_grad, slm->d_token_embedding_m, slm->d_token_embedding_v,
         slm->beta1, slm->beta2, slm->epsilon, learning_rate, slm->weight_decay,
-        alpha_t, token_emb_size, slm->batch_size
+        alpha_t, token_emb_size, effective_batch_size
     );
     
     // Update transformer weights

--- a/gpu/slm.c
+++ b/gpu/slm.c
@@ -270,7 +270,7 @@ __global__ static void adamw_update_kernel_slm(float* weight, float* grad, float
 }
 
 // Update weights
-void update_weights_slm(SLM* slm, float learning_rate) {
+void update_weights_slm(SLM* slm, float learning_rate, int effective_batch_size) {
     slm->t++;
     
     float beta1_t = powf(slm->beta1, slm->t);
@@ -289,10 +289,10 @@ void update_weights_slm(SLM* slm, float learning_rate) {
     );
     
     // Update transformer weights
-    update_weights_transformer(slm->transformer, learning_rate);
+    update_weights_transformer(slm->transformer, learning_rate, effective_batch_size);
     
     // Update output MLP weights
-    update_weights_mlp(slm->output_mlp, learning_rate);
+    update_weights_mlp(slm->output_mlp, learning_rate, effective_batch_size);
 }
 
 // Save SLM to binary file

--- a/gpu/slm.h
+++ b/gpu/slm.h
@@ -80,7 +80,7 @@ void forward_pass_slm(SLM* slm, unsigned char* d_input_tokens);
 float calculate_loss_slm(SLM* slm, unsigned char* d_target_tokens);
 void zero_gradients_slm(SLM* slm);
 void backward_pass_slm(SLM* slm, unsigned char* d_input_tokens);
-void update_weights_slm(SLM* slm, float learning_rate);
+void update_weights_slm(SLM* slm, float learning_rate, int effective_batch_size);
 void save_slm(SLM* slm, const char* filename);
 SLM* load_slm(const char* filename, int custom_batch_size, cublasLtHandle_t cublaslt_handle);
 

--- a/gpu/train.c
+++ b/gpu/train.c
@@ -132,6 +132,7 @@ int main(int argc, char* argv[]) {
     const int num_epochs = 100;
     const float learning_rate = 0.00001f;
     const int num_batches = num_sequences / batch_size;
+    const int accumulation_steps = 1;
 
     // Allocate device memory for batch data
     unsigned char *d_input_tokens, *d_target_tokens;
@@ -165,12 +166,14 @@ int main(int argc, char* argv[]) {
             // Don't update weights after final evaluation
             if (epoch == num_epochs) continue;
 
+            // Zero gradients
+            if (batch % accumulation_steps == 0) zero_gradients_slm(slm);
+            
             // Backward pass
-            zero_gradients_slm(slm);
             backward_pass_slm(slm, d_input_tokens);
             
             // Update weights
-            update_weights_slm(slm, learning_rate, batch_size);
+            if ((batch + 1) % accumulation_steps == 0) update_weights_slm(slm, learning_rate, batch_size * accumulation_steps);
             
             // Print progress
             if (batch % 2 == 0) {

--- a/gpu/train.c
+++ b/gpu/train.c
@@ -170,7 +170,7 @@ int main(int argc, char* argv[]) {
             backward_pass_slm(slm, d_input_tokens);
             
             // Update weights
-            update_weights_slm(slm, learning_rate);
+            update_weights_slm(slm, learning_rate, batch_size);
             
             // Print progress
             if (batch % 2 == 0) {

--- a/slm.c
+++ b/slm.c
@@ -226,7 +226,7 @@ void update_weights_slm(SLM* slm, float learning_rate, int effective_batch_size)
     
     // Update token embeddings
     for (int i = 0; i < token_emb_size; i++) {
-        float grad = slm->token_embedding_grad[i] / slm->batch_size;
+        float grad = slm->token_embedding_grad[i] / effective_batch_size;
         
         // m = β₁m + (1-β₁)(∂L/∂W)
         slm->token_embedding_m[i] = slm->beta1 * slm->token_embedding_m[i] + (1.0f - slm->beta1) * grad;

--- a/slm.c
+++ b/slm.c
@@ -215,7 +215,7 @@ void backward_pass_slm(SLM* slm, unsigned char* input_tokens) {
 }
 
 // Update weights
-void update_weights_slm(SLM* slm, float learning_rate) {
+void update_weights_slm(SLM* slm, float learning_rate, int effective_batch_size) {
     slm->t++;
     
     float beta1_t = powf(slm->beta1, slm->t);
@@ -239,10 +239,10 @@ void update_weights_slm(SLM* slm, float learning_rate) {
     }
     
     // Update transformer weights
-    update_weights_transformer(slm->transformer, learning_rate);
+    update_weights_transformer(slm->transformer, learning_rate, effective_batch_size);
     
     // Update output MLP weights
-    update_weights_mlp(slm->output_mlp, learning_rate);
+    update_weights_mlp(slm->output_mlp, learning_rate, effective_batch_size);
 }
 
 // Save SLM to binary file

--- a/slm.h
+++ b/slm.h
@@ -49,7 +49,7 @@ void forward_pass_slm(SLM* slm, unsigned char* input_tokens);
 float calculate_loss_slm(SLM* slm, unsigned char* target_tokens);
 void zero_gradients_slm(SLM* slm);
 void backward_pass_slm(SLM* slm, unsigned char* input_tokens);
-void update_weights_slm(SLM* slm, float learning_rate);
+void update_weights_slm(SLM* slm, float learning_rate, int effective_batch_size);
 void save_slm(SLM* slm, const char* filename);
 SLM* load_slm(const char* filename, int custom_batch_size);
 

--- a/train.c
+++ b/train.c
@@ -148,7 +148,7 @@ int main(int argc, char* argv[]) {
             backward_pass_slm(slm, &input_chars[batch_offset]);
             
             // Update weights
-            update_weights_slm(slm, learning_rate);
+            update_weights_slm(slm, learning_rate, batch_size);
             
             // Print progress
             if (batch % 2 == 0) {


### PR DESCRIPTION
**Description:**
This update introduces support for **gradient accumulation** by adding an `effective_batch_size` parameter to the `update_weights_slm` and related functions. This allows training over multiple smaller batches before performing a weight update, enabling more efficient memory usage and stable optimization for large models.

**Key Changes:**

* Modified `update_weights_slm`, `update_weights_transformer`, and `update_weights_mlp` to accept an additional `effective_batch_size` parameter.
* Updated gradient normalization to divide by `effective_batch_size` instead of `slm->batch_size`.
* Adjusted training loop in `train.c` to include an `accumulation_steps` variable and conditionally perform gradient zeroing and weight updates.
* Updated corresponding function declarations in header files (`slm.h`, `gpu/slm.h`).
* Updated submodule `transformer` to commit `aa2426eec2d05e1ecc74142dbc352f947f3c26245`.

**Impact:**
This change enables flexible control over effective batch size, making it easier to train large models with limited GPU memory by accumulating gradients across several mini-batches before updating weights.
