### PR TITLE
Implement Global Data Shuffling for Training

### DIFF
--- a/data.c
+++ b/data.c
@@ -31,20 +31,16 @@ size_t* create_shuffled_indices(size_t total_sequences) {
 }
 
 // Sample sequences using shuffled indices
-size_t sample_sequences(const char* filename, size_t* indices, size_t start_idx, int seq_len, unsigned char* input_tokens, unsigned char* target_tokens, size_t num_sequences) {
+void sample_sequences(const char* filename, size_t* indices, int seq_len, unsigned char* input_tokens, unsigned char* target_tokens, size_t num_sequences) {
     FILE* f = fopen(filename, "rb");
-    if (!f) return 0;
+    if (!f) return;
     
     unsigned char* buffer = (unsigned char*)malloc((seq_len + 1) * sizeof(unsigned char));
     
     for (size_t i = 0; i < num_sequences; i++) {
-        fseek(f, indices[start_idx + i] * seq_len, SEEK_SET);
+        fseek(f, indices[i] * seq_len, SEEK_SET);
         
-        if (fread(buffer, 1, seq_len + 1, f) < (size_t)(seq_len + 1)) {
-            free(buffer);
-            fclose(f);
-            return i;
-        }
+        if (fread(buffer, 1, seq_len + 1, f) < (size_t)(seq_len + 1)) break;
         
         for (int j = 0; j < seq_len; j++) {
             input_tokens[i * seq_len + j] = buffer[j];
@@ -54,5 +50,4 @@ size_t sample_sequences(const char* filename, size_t* indices, size_t start_idx,
     
     free(buffer);
     fclose(f);
-    return num_sequences;
 }

--- a/data.c
+++ b/data.c
@@ -10,61 +10,49 @@ size_t get_file_size(const char* filename) {
     return size;
 }
 
-// Read a chunk from an open file
-size_t read_chunk(FILE* f, char* buffer, size_t size) {
-    return fread(buffer, 1, size, f);
+// Create shuffled sequence indices for entire corpus
+size_t* create_shuffled_indices(size_t total_sequences) {
+    size_t* indices = (size_t*)malloc(total_sequences * sizeof(size_t));
+    
+    // Initialize sequentially
+    for (size_t i = 0; i < total_sequences; i++) {
+        indices[i] = i;
+    }
+    
+    // Fisher-Yates shuffle
+    for (size_t i = total_sequences - 1; i > 0; i--) {
+        size_t j = rand() % (i + 1);
+        size_t temp = indices[i];
+        indices[i] = indices[j];
+        indices[j] = temp;
+    }
+    
+    return indices;
 }
 
-// Generate training sequences from a corpus chunk
-void generate_sequences(unsigned char* input_tokens, unsigned char* target_tokens, int seq_len, char* chunk, size_t chunk_size) {
-    // Calculate number of complete non-overlapping sequences
-    // Each sequence needs seq_len chars for input, plus 1 more for the last target
-    int num_sequences = (chunk_size - 1) / seq_len;
+// Sample sequences using shuffled indices
+size_t sample_sequences(const char* filename, size_t* indices, size_t start_idx, int seq_len, unsigned char* input_tokens, unsigned char* target_tokens, size_t num_sequences) {
+    FILE* f = fopen(filename, "rb");
+    if (!f) return 0;
     
-    if (num_sequences <= 0) return;
-
-    // Extract non-overlapping sequences sequentially
-    for (int i = 0; i < num_sequences; i++) {
-        size_t start = i * seq_len;
+    unsigned char* buffer = (unsigned char*)malloc((seq_len + 1) * sizeof(unsigned char));
+    
+    for (size_t i = 0; i < num_sequences; i++) {
+        fseek(f, indices[start_idx + i] * seq_len, SEEK_SET);
         
-        // Copy input sequence and target sequence (shifted by 1)
+        if (fread(buffer, 1, seq_len + 1, f) < (size_t)(seq_len + 1)) {
+            free(buffer);
+            fclose(f);
+            return i;
+        }
+        
         for (int j = 0; j < seq_len; j++) {
-            input_tokens[i * seq_len + j] = (unsigned char)chunk[start + j];
-            target_tokens[i * seq_len + j] = (unsigned char)chunk[start + j + 1];
+            input_tokens[i * seq_len + j] = buffer[j];
+            target_tokens[i * seq_len + j] = buffer[j + 1];
         }
     }
     
-    // Fisher-Yates shuffle the sequences
-    for (int i = num_sequences - 1; i > 0; i--) {
-        int j = rand() % (i + 1);
-        
-        // Swap sequence i with sequence j
-        for (int k = 0; k < seq_len; k++) {
-            // Swap input tokens
-            unsigned char temp = input_tokens[i * seq_len + k];
-            input_tokens[i * seq_len + k] = input_tokens[j * seq_len + k];
-            input_tokens[j * seq_len + k] = temp;
-            
-            // Swap target tokens
-            temp = target_tokens[i * seq_len + k];
-            target_tokens[i * seq_len + k] = target_tokens[j * seq_len + k];
-            target_tokens[j * seq_len + k] = temp;
-        }
-    }
-}
-
-// Calculate total number of batches we'll train on
-size_t calculate_total_batches(const char* filename, int seq_len, int batch_size, size_t chunk_size) {
-    size_t total_size = get_file_size(filename);
-    size_t num_complete_chunks = total_size / chunk_size;
-    size_t sequences_per_chunk = (chunk_size - 1) / seq_len;
-    size_t batches_per_chunk = sequences_per_chunk / batch_size;
-    return num_complete_chunks * batches_per_chunk;
-}
-
-// Calculate current batch number
-size_t calculate_batch_number(FILE* f, size_t chunk_size, int current_batch_in_chunk, int seq_len, int batch_size) {
-    size_t chunks_completed = (ftell(f) / chunk_size) - 1;
-    size_t batches_per_chunk = ((chunk_size - 1) / seq_len) / batch_size;
-    return chunks_completed * batches_per_chunk + current_batch_in_chunk + 1;
+    free(buffer);
+    fclose(f);
+    return num_sequences;
 }

--- a/data.h
+++ b/data.h
@@ -12,6 +12,6 @@ size_t get_file_size(const char* filename);
 size_t* create_shuffled_indices(size_t total_sequences);
 
 // Sample sequences using shuffled indices
-size_t sample_sequences(const char* filename, size_t* indices, size_t start_idx, int seq_len, unsigned char* input_tokens, unsigned char* target_tokens, size_t num_sequences);
+void sample_sequences(const char* filename, size_t* indices, int seq_len, unsigned char* input_tokens, unsigned char* target_tokens, size_t num_sequences);
 
 #endif

--- a/data.h
+++ b/data.h
@@ -8,16 +8,10 @@
 // Get the total size of a file
 size_t get_file_size(const char* filename);
 
-// Read a chunk from an open file
-size_t read_chunk(FILE* f, char* buffer, size_t size);
+// Create shuffled sequence indices for entire corpus
+size_t* create_shuffled_indices(size_t total_sequences);
 
-// Generate training sequences from a corpus chunk
-void generate_sequences(unsigned char* input_tokens, unsigned char* target_tokens, int seq_len, char* chunk, size_t chunk_size);
-
-// Calculate total number of batches we'll train on
-size_t calculate_total_batches(const char* filename, int seq_len, int batch_size, size_t chunk_size);
-
-// Calculate current batch number
-size_t calculate_batch_number(FILE* f, size_t chunk_size, int current_batch_in_chunk, int seq_len, int batch_size);
+// Sample sequences using shuffled indices
+size_t sample_sequences(const char* filename, size_t* indices, size_t start_idx, int seq_len, unsigned char* input_tokens, unsigned char* target_tokens, size_t num_sequences);
 
 #endif

--- a/gpu/train.c
+++ b/gpu/train.c
@@ -130,11 +130,10 @@ int main(int argc, char* argv[]) {
     // Training loop: process corpus in chunks with random sampling
     for (size_t chunk_idx = 0; chunk_idx < total_chunks; chunk_idx++) {
         // Sample next chunk of sequences from shuffled corpus
-        size_t sequences_sampled = sample_sequences("../corpus.txt", shuffled_indices, chunk_idx * sequences_per_chunk, seq_len, input_tokens, target_tokens, sequences_per_chunk);
-        if (sequences_sampled == 0) break;
+        sample_sequences("../corpus.txt", &shuffled_indices[chunk_idx * sequences_per_chunk], seq_len, input_tokens, target_tokens, sequences_per_chunk);
         
         // Calculate batches in this chunk
-        int batches_in_chunk = sequences_sampled / batch_size;
+        int batches_in_chunk = sequences_per_chunk / batch_size;
         
         // Train on all batches in this chunk
         for (int batch = 0; batch < batches_in_chunk; batch++) {

--- a/gpu/train.c
+++ b/gpu/train.c
@@ -132,11 +132,8 @@ int main(int argc, char* argv[]) {
         // Sample next chunk of sequences from shuffled corpus
         sample_sequences("../corpus.txt", &shuffled_indices[chunk_idx * sequences_per_chunk], seq_len, input_tokens, target_tokens, sequences_per_chunk);
         
-        // Calculate batches in this chunk
-        int batches_in_chunk = sequences_per_chunk / batch_size;
-        
         // Train on all batches in this chunk
-        for (int batch = 0; batch < batches_in_chunk; batch++) {
+        for (int batch = 0; batch < (int)(sequences_per_chunk / batch_size); batch++) {
             // Copy batch to device
             CHECK_CUDA(cudaMemcpy(d_input_tokens, &input_tokens[batch * batch_size * seq_len], batch_size * seq_len, cudaMemcpyHostToDevice));
             CHECK_CUDA(cudaMemcpy(d_target_tokens, &target_tokens[batch * batch_size * seq_len], batch_size * seq_len, cudaMemcpyHostToDevice));
@@ -156,7 +153,7 @@ int main(int argc, char* argv[]) {
             float lr = learning_rate * (0.5f * (1.0f + cosf(M_PI * ((float)((chunk_idx * (sequences_per_chunk / batch_size) + batch)) / (float)(total_sequences / batch_size)))));
             update_weights_slm(slm, lr, batch_size);
             
-            printf("Chunk [%zu/%zu], Batch [%d/%d], Loss: %.6f, LR: %.7f\n", chunk_idx, total_chunks, batch, batches_in_chunk, loss, lr);
+            printf("Chunk [%zu/%zu], Batch [%d/%d], Loss: %.6f, LR: %.7f\n", chunk_idx, total_chunks, batch, (int)(sequences_per_chunk / batch_size), loss, lr);
         }
         
         // Generate sample text

--- a/train.c
+++ b/train.c
@@ -63,7 +63,7 @@ void generate_text(SLM* slm, float temperature, const char* bos, int gen_len) {
         unsigned char next_token = 0;
         float cumsum = 0.0f;
         for (int v = 0; v < slm->vocab_size; v++) {
-            cumsum += h_logits[v];
+            cumsum += logits[v];
             if (r <= cumsum) {
                 next_token = v;
                 break;
@@ -118,11 +118,10 @@ int main(int argc, char* argv[]) {
     // Training loop: process corpus in chunks with random sampling
     for (size_t chunk_idx = 0; chunk_idx < total_chunks; chunk_idx++) {
         // Sample next chunk of sequences from shuffled corpus
-        size_t sequences_sampled = sample_sequences("corpus.txt", shuffled_indices, chunk_idx * sequences_per_chunk, seq_len, input_tokens, target_tokens, sequences_per_chunk);
-        if (sequences_sampled == 0) break;
+        sample_sequences("corpus.txt", &shuffled_indices[chunk_idx * sequences_per_chunk], seq_len, input_tokens, target_tokens, sequences_per_chunk);
         
         // Calculate batches in this chunk
-        int batches_in_chunk = sequences_sampled / batch_size;
+        int batches_in_chunk = sequences_per_chunk / batch_size;
         
         // Train on all batches in this chunk
         for (int batch = 0; batch < batches_in_chunk; batch++) {

--- a/train.c
+++ b/train.c
@@ -120,11 +120,8 @@ int main(int argc, char* argv[]) {
         // Sample next chunk of sequences from shuffled corpus
         sample_sequences("corpus.txt", &shuffled_indices[chunk_idx * sequences_per_chunk], seq_len, input_tokens, target_tokens, sequences_per_chunk);
         
-        // Calculate batches in this chunk
-        int batches_in_chunk = sequences_per_chunk / batch_size;
-        
         // Train on all batches in this chunk
-        for (int batch = 0; batch < batches_in_chunk; batch++) {
+        for (int batch = 0; batch < (int)(sequences_per_chunk / batch_size); batch++) {
             // Forward pass
             forward_pass_slm(slm, &input_tokens[batch * batch_size * seq_len]);
             
@@ -140,7 +137,7 @@ int main(int argc, char* argv[]) {
             float lr = learning_rate * (0.5f * (1.0f + cosf(M_PI * ((float)((chunk_idx * (sequences_per_chunk / batch_size) + batch)) / (float)(total_sequences / batch_size)))));
             update_weights_slm(slm, lr, batch_size);
             
-            printf("Chunk [%zu/%zu], Batch [%d/%d], Loss: %.6f, LR: %.7f\n", chunk_idx, total_chunks, batch, batches_in_chunk, loss, lr);
+            printf("Chunk [%zu/%zu], Batch [%d/%d], Loss: %.6f, LR: %.7f\n", chunk_idx, total_chunks, batch, (int)(sequences_per_chunk / batch_size), loss, lr);
         }
         
         // Generate sample text

--- a/train.c
+++ b/train.c
@@ -107,16 +107,13 @@ int main(int argc, char* argv[]) {
     size_t total_sequences = (get_file_size("corpus.txt") - 1) / seq_len;
     size_t* shuffled_indices = create_shuffled_indices(total_sequences);
     
-    // Calculate chunk size and total chunks
-    size_t sequences_per_chunk = (128 * 1024 * 1024) / seq_len;
-    size_t total_chunks = total_sequences / sequences_per_chunk;
-    
     // Allocate buffers for sequences
+    size_t sequences_per_chunk = (128 * 1024 * 1024) / seq_len;
     unsigned char* input_tokens = (unsigned char*)malloc(sequences_per_chunk * seq_len);
     unsigned char* target_tokens = (unsigned char*)malloc(sequences_per_chunk * seq_len);
     
     // Training loop: process corpus in chunks with random sampling
-    for (size_t chunk_idx = 0; chunk_idx < total_chunks; chunk_idx++) {
+    for (size_t chunk_idx = 0; chunk_idx < total_sequences / sequences_per_chunk; chunk_idx++) {
         // Sample next chunk of sequences from shuffled corpus
         sample_sequences("corpus.txt", &shuffled_indices[chunk_idx * sequences_per_chunk], seq_len, input_tokens, target_tokens, sequences_per_chunk);
         
@@ -137,7 +134,7 @@ int main(int argc, char* argv[]) {
             float lr = learning_rate * (0.5f * (1.0f + cosf(M_PI * ((float)((chunk_idx * (sequences_per_chunk / batch_size) + batch)) / (float)(total_sequences / batch_size)))));
             update_weights_slm(slm, lr, batch_size);
             
-            printf("Chunk [%zu/%zu], Batch [%d/%d], Loss: %.6f, LR: %.7f\n", chunk_idx, total_chunks, batch, (int)(sequences_per_chunk / batch_size), loss, lr);
+            printf("Chunk [%zu/%zu], Batch [%d/%d], Loss: %.6f, LR: %.7f\n", chunk_idx, total_sequences / sequences_per_chunk, batch, (int)(sequences_per_chunk / batch_size), loss, lr);
         }
         
         // Generate sample text

--- a/train.c
+++ b/train.c
@@ -63,7 +63,7 @@ void generate_text(SLM* slm, float temperature, const char* bos, int gen_len) {
         unsigned char next_token = 0;
         float cumsum = 0.0f;
         for (int v = 0; v < slm->vocab_size; v++) {
-            cumsum += logits[v];
+            cumsum += h_logits[v];
             if (r <= cumsum) {
                 next_token = v;
                 break;
@@ -103,30 +103,26 @@ int main(int argc, char* argv[]) {
     
     printf("Parameters: ~%.1fM\n", (float)(slm->vocab_size * d_model + d_model * slm->vocab_size + num_layers * (4 * d_model * d_model + d_model * hidden_dim + hidden_dim * d_model)) / 1e6f);
     
-    // Open corpus file
-    FILE* f = fopen("corpus.txt", "rb");
+    // Create shuffled indices for random sampling without replacement
+    size_t total_sequences = (get_file_size("corpus.txt") - 1) / seq_len;
+    size_t* shuffled_indices = create_shuffled_indices(total_sequences);
     
-    // Calculate total chunks
-    size_t chunk_size = 128 * 1024 * 1024;
-    size_t total_chunks = get_file_size("corpus.txt") / chunk_size;
+    // Calculate chunk size and total chunks
+    size_t sequences_per_chunk = (128 * 1024 * 1024) / seq_len;
+    size_t total_chunks = total_sequences / sequences_per_chunk;
     
-    // Allocate buffers
-    char* chunk = (char*)malloc(chunk_size);
-    int max_sequences = chunk_size / seq_len;
-    unsigned char* input_tokens = (unsigned char*)malloc(max_sequences * seq_len);
-    unsigned char* target_tokens = (unsigned char*)malloc(max_sequences * seq_len);
+    // Allocate buffers for sequences
+    unsigned char* input_tokens = (unsigned char*)malloc(sequences_per_chunk * seq_len);
+    unsigned char* target_tokens = (unsigned char*)malloc(sequences_per_chunk * seq_len);
     
-    // Training loop: process corpus in chunks
+    // Training loop: process corpus in chunks with random sampling
     for (size_t chunk_idx = 0; chunk_idx < total_chunks; chunk_idx++) {
-        // Read next chunk
-        size_t loaded = read_chunk(f, chunk, chunk_size);
-        if (loaded < chunk_size) break;
-        
-        // Generate random training sequences from chunk
-        generate_sequences(input_tokens, target_tokens, seq_len, chunk, loaded);
+        // Sample next chunk of sequences from shuffled corpus
+        size_t sequences_sampled = sample_sequences("corpus.txt", shuffled_indices, chunk_idx * sequences_per_chunk, seq_len, input_tokens, target_tokens, sequences_per_chunk);
+        if (sequences_sampled == 0) break;
         
         // Calculate batches in this chunk
-        int batches_in_chunk = ((int)loaded / seq_len) / batch_size;
+        int batches_in_chunk = sequences_sampled / batch_size;
         
         // Train on all batches in this chunk
         for (int batch = 0; batch < batches_in_chunk; batch++) {
@@ -142,7 +138,7 @@ int main(int argc, char* argv[]) {
             backward_pass_slm(slm, &input_tokens[batch * batch_size * seq_len]);
             
             // Update weights with cosine learning rate schedule
-            float lr = learning_rate * (0.5f * (1.0f + cosf(M_PI * ((float)((calculate_batch_number(f, chunk_size, batch, seq_len, batch_size)) - 1) / (float)(calculate_total_batches("corpus.txt", seq_len, batch_size, chunk_size))))));
+            float lr = learning_rate * (0.5f * (1.0f + cosf(M_PI * ((float)((chunk_idx * (sequences_per_chunk / batch_size) + batch)) / (float)(total_sequences / batch_size)))));
             update_weights_slm(slm, lr, batch_size);
             
             printf("Chunk [%zu/%zu], Batch [%d/%d], Loss: %.6f, LR: %.7f\n", chunk_idx, total_chunks, batch, batches_in_chunk, loss, lr);
@@ -164,10 +160,9 @@ int main(int argc, char* argv[]) {
     save_slm(slm, filename);
     
     // Cleanup
-    fclose(f);
-    free(chunk);
     free(input_tokens);
     free(target_tokens);
+    free(shuffled_indices);
     free_slm(slm);
     
     return 0;


### PR DESCRIPTION
This pull request refactors the data loading and sampling mechanism to improve the randomness of training batches.

Previously, the training process involved reading a large, sequential chunk of the corpus into memory and then shuffling the training sequences only within that chunk. This approach limited the diversity of batches, as sequences from different parts of the corpus were never mixed.

This update introduces a more robust shuffling strategy:

*   **Pre-computation of Shuffled Indices:** Before training starts, the program now generates a shuffled list of indices for every possible sequence in the entire dataset using a Fisher-Yates shuffle.
*   **Random Sampling:** During training, the data loader uses these shuffled indices to read sequences directly from the corpus file. This ensures that each batch is composed of sequences randomly sampled from the entire dataset, rather than from a localized chunk.
*   **Code Simplification:** The previous functions for chunk-based reading and in-chunk shuffling (`read_chunk`, `generate_sequences`) have been removed and replaced with the cleaner `create_shuffled_indices` and `sample_sequences` functions.

This change ensures a more uniform and random sampling of training data across epochs, which is expected to improve model generalization and training stability.