### PR TITLE
Refactor model serialization to use single file format

### DIFF
--- a/gpu/slm.c
+++ b/gpu/slm.c
@@ -342,7 +342,6 @@ static void serialize_slm(SLM* slm, FILE* file) {
     // Write dimensions
     fwrite(&slm->seq_len, sizeof(int), 1, file);
     fwrite(&slm->d_model, sizeof(int), 1, file);
-    fwrite(&slm->batch_size, sizeof(int), 1, file);
     fwrite(&slm->hidden_dim, sizeof(int), 1, file);
     fwrite(&slm->num_layers, sizeof(int), 1, file);
     fwrite(&slm->vocab_size, sizeof(int), 1, file);
@@ -390,18 +389,14 @@ static void serialize_slm(SLM* slm, FILE* file) {
 }
 
 // Deserialize SLM from a file
-static SLM* deserialize_slm(FILE* file, int custom_batch_size, cublasLtHandle_t cublaslt_handle) {
+static SLM* deserialize_slm(FILE* file, int batch_size, cublasLtHandle_t cublaslt_handle) {
     // Read dimensions
-    int seq_len, d_model, stored_batch_size, hidden_dim, num_layers, vocab_size;
+    int seq_len, d_model, hidden_dim, num_layers, vocab_size;
     fread(&seq_len, sizeof(int), 1, file);
     fread(&d_model, sizeof(int), 1, file);
-    fread(&stored_batch_size, sizeof(int), 1, file);
     fread(&hidden_dim, sizeof(int), 1, file);
     fread(&num_layers, sizeof(int), 1, file);
     fread(&vocab_size, sizeof(int), 1, file);
-    
-    // Use custom batch size if provided
-    int batch_size = (custom_batch_size > 0) ? custom_batch_size : stored_batch_size;
     
     // Initialize SLM
     SLM* slm = init_slm(seq_len, d_model, hidden_dim, num_layers, batch_size, cublaslt_handle);
@@ -467,14 +462,14 @@ void save_slm(SLM* slm, const char* filename) {
 }
 
 // Load SLM from a file
-SLM* load_slm(const char* filename, int custom_batch_size, cublasLtHandle_t cublaslt_handle) {
+SLM* load_slm(const char* filename, int batch_size, cublasLtHandle_t cublaslt_handle) {
     FILE* file = fopen(filename, "rb");
     if (!file) {
         printf("Error opening file for reading: %s\n", filename);
         return NULL;
     }
     
-    SLM* slm = deserialize_slm(file, custom_batch_size, cublaslt_handle);
+    SLM* slm = deserialize_slm(file, batch_size, cublaslt_handle);
     
     fclose(file);
     printf("Model loaded from %s\n", filename);

--- a/gpu/slm.c
+++ b/gpu/slm.c
@@ -337,15 +337,9 @@ void update_weights_slm(SLM* slm, float learning_rate, int effective_batch_size)
     update_weights_transformer(slm->transformer, learning_rate, effective_batch_size);
 }
 
-// Save SLM to binary file
-void save_slm(SLM* slm, const char* filename) {
-    FILE* file = fopen(filename, "wb");
-    if (!file) {
-        printf("Error opening file for writing: %s\n", filename);
-        return;
-    }
-    
-    // Save dimensions
+// Serialize SLM to a file
+static void serialize_slm(SLM* slm, FILE* file) {
+    // Write dimensions
     fwrite(&slm->seq_len, sizeof(int), 1, file);
     fwrite(&slm->d_model, sizeof(int), 1, file);
     fwrite(&slm->batch_size, sizeof(int), 1, file);
@@ -363,10 +357,14 @@ void save_slm(SLM* slm, const char* filename) {
     CHECK_CUDA(cudaMemcpy(h_token_embedding, slm->d_token_embedding, token_emb_size * sizeof(float), cudaMemcpyDeviceToHost));
     CHECK_CUDA(cudaMemcpy(h_W_output, slm->d_W_output, output_weight_size * sizeof(float), cudaMemcpyDeviceToHost));
     
+    // Write embeddings and weights
     fwrite(h_token_embedding, sizeof(float), token_emb_size, file);
     fwrite(h_W_output, sizeof(float), output_weight_size, file);
     
-    // Save Adam state
+    free(h_token_embedding);
+    free(h_W_output);
+    
+    // Write optimizer state
     fwrite(&slm->t, sizeof(int), 1, file);
     
     float* h_token_embedding_m = (float*)malloc(token_emb_size * sizeof(float));
@@ -384,42 +382,15 @@ void save_slm(SLM* slm, const char* filename) {
     fwrite(h_W_output_m, sizeof(float), output_weight_size, file);
     fwrite(h_W_output_v, sizeof(float), output_weight_size, file);
     
-    fclose(file);
-    
-    // Save transformer
-    char transformer_filename[256];
-    char base_filename[256];
-    
-    // Remove .bin extension from filename to create base name
-    strncpy(base_filename, filename, sizeof(base_filename) - 1);
-    base_filename[sizeof(base_filename) - 1] = '\0';
-    
-    // Find and remove .bin extension if it exists
-    char* dot_pos = strrchr(base_filename, '.');
-    if (dot_pos && strcmp(dot_pos, ".bin") == 0) {
-        *dot_pos = '\0';
-    }
-    
-    snprintf(transformer_filename, sizeof(transformer_filename), "%s_transformer.bin", base_filename);
-    save_transformer(slm->transformer, transformer_filename);
-    
-    // Free temporary host memory
-    free(h_token_embedding);
-    free(h_W_output);
     free(h_token_embedding_m); free(h_token_embedding_v);
     free(h_W_output_m); free(h_W_output_v);
-
-    printf("Model saved to %s\n", filename);
+    
+    // Serialize transformer
+    serialize_transformer(slm->transformer, file);
 }
 
-// Load SLM from binary file
-SLM* load_slm(const char* filename, int custom_batch_size, cublasLtHandle_t cublaslt_handle) {
-    FILE* file = fopen(filename, "rb");
-    if (!file) {
-        printf("Error opening file for reading: %s\n", filename);
-        return NULL;
-    }
-    
+// Deserialize SLM from a file
+static SLM* deserialize_slm(FILE* file, int custom_batch_size, cublasLtHandle_t cublaslt_handle) {
     // Read dimensions
     int seq_len, d_model, stored_batch_size, hidden_dim, num_layers, vocab_size;
     fread(&seq_len, sizeof(int), 1, file);
@@ -429,7 +400,7 @@ SLM* load_slm(const char* filename, int custom_batch_size, cublasLtHandle_t cubl
     fread(&num_layers, sizeof(int), 1, file);
     fread(&vocab_size, sizeof(int), 1, file);
     
-    // Use custom_batch_size if provided, otherwise use stored value
+    // Use custom batch size if provided
     int batch_size = (custom_batch_size > 0) ? custom_batch_size : stored_batch_size;
     
     // Initialize SLM
@@ -448,7 +419,10 @@ SLM* load_slm(const char* filename, int custom_batch_size, cublasLtHandle_t cubl
     CHECK_CUDA(cudaMemcpy(slm->d_token_embedding, h_token_embedding, token_emb_size * sizeof(float), cudaMemcpyHostToDevice));
     CHECK_CUDA(cudaMemcpy(slm->d_W_output, h_W_output, output_weight_size * sizeof(float), cudaMemcpyHostToDevice));
     
-    // Load Adam state
+    free(h_token_embedding);
+    free(h_W_output);
+    
+    // Load optimizer state
     fread(&slm->t, sizeof(int), 1, file);
     
     float* h_token_embedding_m = (float*)malloc(token_emb_size * sizeof(float));
@@ -466,36 +440,43 @@ SLM* load_slm(const char* filename, int custom_batch_size, cublasLtHandle_t cubl
     CHECK_CUDA(cudaMemcpy(slm->d_W_output_m, h_W_output_m, output_weight_size * sizeof(float), cudaMemcpyHostToDevice));
     CHECK_CUDA(cudaMemcpy(slm->d_W_output_v, h_W_output_v, output_weight_size * sizeof(float), cudaMemcpyHostToDevice));
     
-    fclose(file);
-    
-    // Load transformer
-    char transformer_filename[256];
-    char base_filename[256];
-    
-    // Remove .bin extension from filename to create base name  
-    strncpy(base_filename, filename, sizeof(base_filename) - 1);
-    base_filename[sizeof(base_filename) - 1] = '\0';
-    
-    // Find and remove .bin extension if it exists
-    char* dot_pos = strrchr(base_filename, '.');
-    if (dot_pos && strcmp(dot_pos, ".bin") == 0) {
-        *dot_pos = '\0';
-    }
-    
-    snprintf(transformer_filename, sizeof(transformer_filename), "%s_transformer.bin", base_filename);
+    free(h_token_embedding_m); free(h_token_embedding_v);
+    free(h_W_output_m); free(h_W_output_v);
     
     // Free the initialized transformer
     free_transformer(slm->transformer);
     
-    // Load the saved transformer
-    slm->transformer = load_transformer(transformer_filename, batch_size, cublaslt_handle);
+    // Deserialize transformer
+    slm->transformer = deserialize_transformer(file, batch_size, cublaslt_handle);
     
-    // Free temporary host memory
-    free(h_token_embedding);
-    free(h_W_output);
-    free(h_token_embedding_m); free(h_token_embedding_v);
-    free(h_W_output_m); free(h_W_output_v);
+    return slm;
+}
+
+// Save SLM to a file
+void save_slm(SLM* slm, const char* filename) {
+    FILE* file = fopen(filename, "wb");
+    if (!file) {
+        printf("Error opening file for writing: %s\n", filename);
+        return;
+    }
     
+    serialize_slm(slm, file);
+    
+    fclose(file);
+    printf("Model saved to %s\n", filename);
+}
+
+// Load SLM from a file
+SLM* load_slm(const char* filename, int custom_batch_size, cublasLtHandle_t cublaslt_handle) {
+    FILE* file = fopen(filename, "rb");
+    if (!file) {
+        printf("Error opening file for reading: %s\n", filename);
+        return NULL;
+    }
+    
+    SLM* slm = deserialize_slm(file, custom_batch_size, cublaslt_handle);
+    
+    fclose(file);
     printf("Model loaded from %s\n", filename);
     return slm;
 }

--- a/gpu/slm.h
+++ b/gpu/slm.h
@@ -109,6 +109,6 @@ void zero_gradients_slm(SLM* slm);
 void backward_pass_slm(SLM* slm, unsigned short* d_input_tokens);
 void update_weights_slm(SLM* slm, float learning_rate, int effective_batch_size);
 void save_slm(SLM* slm, const char* filename);
-SLM* load_slm(const char* filename, int custom_batch_size, cublasLtHandle_t cublaslt_handle);
+SLM* load_slm(const char* filename, int batch_size, cublasLtHandle_t cublaslt_handle);
 
 #endif

--- a/slm.c
+++ b/slm.c
@@ -260,15 +260,9 @@ void update_weights_slm(SLM* slm, float learning_rate, int effective_batch_size)
     update_weights_transformer(slm->transformer, learning_rate, effective_batch_size);
 }
 
-// Save SLM to binary file
-void save_slm(SLM* slm, const char* filename) {
-    FILE* file = fopen(filename, "wb");
-    if (!file) {
-        printf("Error opening file for writing: %s\n", filename);
-        return;
-    }
-    
-    // Save dimensions
+// Serialize SLM to a file
+static void serialize_slm(SLM* slm, FILE* file) {
+    // Write dimensions
     fwrite(&slm->seq_len, sizeof(int), 1, file);
     fwrite(&slm->d_model, sizeof(int), 1, file);
     fwrite(&slm->batch_size, sizeof(int), 1, file);
@@ -279,47 +273,23 @@ void save_slm(SLM* slm, const char* filename) {
     int token_emb_size = slm->vocab_size * slm->d_model;
     int output_weight_size = slm->d_model * slm->vocab_size;
     
-    // Save embeddings and weights
+    // Write embeddings and weights
     fwrite(slm->token_embedding, sizeof(float), token_emb_size, file);
     fwrite(slm->W_output, sizeof(float), output_weight_size, file);
     
-    // Save Adam state
+    // Write optimizer state
     fwrite(&slm->t, sizeof(int), 1, file);
     fwrite(slm->token_embedding_m, sizeof(float), token_emb_size, file);
     fwrite(slm->token_embedding_v, sizeof(float), token_emb_size, file);
     fwrite(slm->W_output_m, sizeof(float), output_weight_size, file);
     fwrite(slm->W_output_v, sizeof(float), output_weight_size, file);
     
-    fclose(file);
-    
-    // Save transformer
-    char transformer_filename[256];
-    char base_filename[256];
-    
-    // Remove .bin extension from filename to create base name
-    strncpy(base_filename, filename, sizeof(base_filename) - 1);
-    base_filename[sizeof(base_filename) - 1] = '\0';
-    
-    // Find and remove .bin extension if it exists
-    char* dot_pos = strrchr(base_filename, '.');
-    if (dot_pos && strcmp(dot_pos, ".bin") == 0) {
-        *dot_pos = '\0';
-    }
-    
-    snprintf(transformer_filename, sizeof(transformer_filename), "%s_transformer.bin", base_filename);
-    save_transformer(slm->transformer, transformer_filename);
-    
-    printf("Model saved to %s\n", filename);
+    // Serialize transformer
+    serialize_transformer(slm->transformer, file);
 }
 
-// Load SLM from binary file
-SLM* load_slm(const char* filename, int custom_batch_size) {
-    FILE* file = fopen(filename, "rb");
-    if (!file) {
-        printf("Error opening file for reading: %s\n", filename);
-        return NULL;
-    }
-    
+// Deserialize SLM from a file
+static SLM* deserialize_slm(FILE* file, int custom_batch_size) {
     // Read dimensions
     int seq_len, d_model, stored_batch_size, hidden_dim, num_layers, vocab_size;
     fread(&seq_len, sizeof(int), 1, file);
@@ -329,7 +299,7 @@ SLM* load_slm(const char* filename, int custom_batch_size) {
     fread(&num_layers, sizeof(int), 1, file);
     fread(&vocab_size, sizeof(int), 1, file);
     
-    // Use custom_batch_size if provided, otherwise use stored value
+    // Use custom batch size if provided
     int batch_size = (custom_batch_size > 0) ? custom_batch_size : stored_batch_size;
     
     // Initialize SLM
@@ -338,41 +308,51 @@ SLM* load_slm(const char* filename, int custom_batch_size) {
     int token_emb_size = vocab_size * d_model;
     int output_weight_size = d_model * vocab_size;
     
-    // Load embeddings and weights
+    // Read embeddings and weights
     fread(slm->token_embedding, sizeof(float), token_emb_size, file);
     fread(slm->W_output, sizeof(float), output_weight_size, file);
     
-    // Load Adam state
+    // Read optimizer state
     fread(&slm->t, sizeof(int), 1, file);
     fread(slm->token_embedding_m, sizeof(float), token_emb_size, file);
     fread(slm->token_embedding_v, sizeof(float), token_emb_size, file);
     fread(slm->W_output_m, sizeof(float), output_weight_size, file);
     fread(slm->W_output_v, sizeof(float), output_weight_size, file);
     
-    fclose(file);
-    
-    // Load transformer
-    char transformer_filename[256];
-    char base_filename[256];
-    
-    // Remove .bin extension from filename to create base name  
-    strncpy(base_filename, filename, sizeof(base_filename) - 1);
-    base_filename[sizeof(base_filename) - 1] = '\0';
-    
-    // Find and remove .bin extension if it exists
-    char* dot_pos = strrchr(base_filename, '.');
-    if (dot_pos && strcmp(dot_pos, ".bin") == 0) {
-        *dot_pos = '\0';
-    }
-    
-    snprintf(transformer_filename, sizeof(transformer_filename), "%s_transformer.bin", base_filename);
-    
     // Free the initialized transformer
     free_transformer(slm->transformer);
     
-    // Load the saved transformer
-    slm->transformer = load_transformer(transformer_filename, batch_size);
+    // Deserialize transformer
+    slm->transformer = deserialize_transformer(file, batch_size);
     
+    return slm;
+}
+
+// Save SLM to a file
+void save_slm(SLM* slm, const char* filename) {
+    FILE* file = fopen(filename, "wb");
+    if (!file) {
+        printf("Error opening file for writing: %s\n", filename);
+        return;
+    }
+    
+    serialize_slm(slm, file);
+    
+    fclose(file);
+    printf("Model saved to %s\n", filename);
+}
+
+// Load SLM from a file
+SLM* load_slm(const char* filename, int custom_batch_size) {
+    FILE* file = fopen(filename, "rb");
+    if (!file) {
+        printf("Error opening file for reading: %s\n", filename);
+        return NULL;
+    }
+    
+    SLM* slm = deserialize_slm(file, custom_batch_size);
+    
+    fclose(file);
     printf("Model loaded from %s\n", filename);
     return slm;
 }

--- a/slm.c
+++ b/slm.c
@@ -265,7 +265,6 @@ static void serialize_slm(SLM* slm, FILE* file) {
     // Write dimensions
     fwrite(&slm->seq_len, sizeof(int), 1, file);
     fwrite(&slm->d_model, sizeof(int), 1, file);
-    fwrite(&slm->batch_size, sizeof(int), 1, file);
     fwrite(&slm->hidden_dim, sizeof(int), 1, file);
     fwrite(&slm->num_layers, sizeof(int), 1, file);
     fwrite(&slm->vocab_size, sizeof(int), 1, file);
@@ -289,18 +288,14 @@ static void serialize_slm(SLM* slm, FILE* file) {
 }
 
 // Deserialize SLM from a file
-static SLM* deserialize_slm(FILE* file, int custom_batch_size) {
+static SLM* deserialize_slm(FILE* file, int batch_size) {
     // Read dimensions
-    int seq_len, d_model, stored_batch_size, hidden_dim, num_layers, vocab_size;
+    int seq_len, d_model, hidden_dim, num_layers, vocab_size;
     fread(&seq_len, sizeof(int), 1, file);
     fread(&d_model, sizeof(int), 1, file);
-    fread(&stored_batch_size, sizeof(int), 1, file);
     fread(&hidden_dim, sizeof(int), 1, file);
     fread(&num_layers, sizeof(int), 1, file);
     fread(&vocab_size, sizeof(int), 1, file);
-    
-    // Use custom batch size if provided
-    int batch_size = (custom_batch_size > 0) ? custom_batch_size : stored_batch_size;
     
     // Initialize SLM
     SLM* slm = init_slm(seq_len, d_model, hidden_dim, num_layers, batch_size);
@@ -343,14 +338,14 @@ void save_slm(SLM* slm, const char* filename) {
 }
 
 // Load SLM from a file
-SLM* load_slm(const char* filename, int custom_batch_size) {
+SLM* load_slm(const char* filename, int batch_size) {
     FILE* file = fopen(filename, "rb");
     if (!file) {
         printf("Error opening file for reading: %s\n", filename);
         return NULL;
     }
     
-    SLM* slm = deserialize_slm(file, custom_batch_size);
+    SLM* slm = deserialize_slm(file, batch_size);
     
     fclose(file);
     printf("Model loaded from %s\n", filename);

--- a/slm.h
+++ b/slm.h
@@ -57,6 +57,6 @@ void zero_gradients_slm(SLM* slm);
 void backward_pass_slm(SLM* slm, unsigned short* input_tokens);
 void update_weights_slm(SLM* slm, float learning_rate, int effective_batch_size);
 void save_slm(SLM* slm, const char* filename);
-SLM* load_slm(const char* filename, int custom_batch_size);
+SLM* load_slm(const char* filename, int batch_size);
 
 #endif


### PR DESCRIPTION
This PR refactors the SLM save/load functionality to serialize all model components into a single binary file instead of creating separate files for the transformer.

## Changes

### Model Serialization
- **Single file format**: Model now saves to a single `.bin` file instead of creating separate `_transformer.bin` files
- **Refactored save/load functions**: Split into `serialize_slm`/`deserialize_slm` helper functions that work with FILE pointers
- **Removed batch_size from serialization**: No longer saving `batch_size` to disk since it can vary between training and inference

### API Changes
- Renamed parameter: `custom_batch_size` → `batch_size` in `load_slm()` for clarity
- Simplified logic: Removed conditional batch size handling since it's now always required at load time

### Memory Management
- Added explicit `free()` calls immediately after copying data to/from GPU
- Fixed potential memory leaks by freeing temporary buffers earlier

### Code Quality
- Removed complex filename manipulation logic for generating transformer filenames
- Made serialization functions `static` to limit scope to the compilation unit
- Improved consistency between CPU and GPU implementations

## Transformer Submodule
Updated transformer submodule to support the new `serialize_transformer`/`deserialize_transformer` API.

## Benefits
- Simpler file management (single file vs. multiple files)
- Cleaner API with less complexity
- Better memory hygiene with earlier buffer deallocation
- Consistent serialization pattern across all model components