### PR TITLE
Apply memory aliasing optimization and increase batch size

### DIFF
--- a/gpt.c
+++ b/gpt.c
@@ -42,8 +42,8 @@ GPT* init_gpt(int seq_len, int d_model, int hidden_dim, int num_layers, int batc
     gpt->embedded_input = (float*)malloc(embedded_size * sizeof(float));
     gpt->output = (float*)malloc(output_size * sizeof(float));
     
-    // Allocate memory for backward pass buffers
-    gpt->grad_output = (float*)malloc(output_size * sizeof(float));
+    // Alias memory for backward pass buffers
+    gpt->grad_output = gpt->output;
     
     // Initialize token embeddings
     float token_scale = 1.0f / sqrtf(d_model);
@@ -74,7 +74,7 @@ void free_gpt(GPT* gpt) {
     free(gpt->W_output); free(gpt->W_output_grad);
     free(gpt->W_output_m); free(gpt->W_output_v);
     free(gpt->embedded_input);
-    free(gpt->output); free(gpt->grad_output);
+    free(gpt->output);
     
     free(gpt);
 }

--- a/gpu/gpt.c
+++ b/gpu/gpt.c
@@ -59,8 +59,8 @@ GPT* init_gpt(int seq_len, int d_model, int hidden_dim, int num_layers, int batc
     CHECK_CUDA(cudaMalloc(&gpt->d_embedded_input, embedded_size * sizeof(float)));
     CHECK_CUDA(cudaMalloc(&gpt->d_output, output_size * sizeof(float)));
     
-    // Allocate device memory for backward pass buffers
-    CHECK_CUDA(cudaMalloc(&gpt->d_grad_output, output_size * sizeof(float)));
+    // Alias device memory for backward pass buffers
+    gpt->d_grad_output = gpt->d_output;
     
     // Allocate single device float for loss computation
     CHECK_CUDA(cudaMalloc(&gpt->d_loss_result, sizeof(float)));

--- a/gpu/gpt.c
+++ b/gpu/gpt.c
@@ -123,7 +123,7 @@ void free_gpt(GPT* gpt) {
     cudaFree(gpt->d_W_output); cudaFree(gpt->d_W_output_grad);
     cudaFree(gpt->d_W_output_m); cudaFree(gpt->d_W_output_v);
     cudaFree(gpt->d_embedded_input);
-    cudaFree(gpt->d_output); cudaFree(gpt->d_grad_output);
+    cudaFree(gpt->d_output);
     
     // Free loss computation buffer
     cudaFree(gpt->d_loss_result);

--- a/gpu/train.c
+++ b/gpu/train.c
@@ -98,7 +98,7 @@ int main(int argc, char* argv[]) {
     // Model hyperparameters
     const int seq_len = 512;
     const int num_layers = 16;
-    const int batch_size = 19;
+    const int batch_size = 30;
     const int d_model = num_layers * 64;
     const int hidden_dim = d_model * 4;
     const float learning_rate = 0.00003f;


### PR DESCRIPTION
This PR applies memory aliasing optimizations to the GPT model and increases the training batch size to take advantage of the reduced memory footprint.

**Changes:**
- **CPU version (`gpt.c`)**: Changed `grad_output` from a separate allocation to an alias of the `output` buffer
- **GPU version (`gpu/gpt.c`)**: Changed `d_grad_output` from a separate `cudaMalloc` to an alias of the `d_output` buffer
- Updated `free_gpt()` functions in both versions to avoid double-freeing the aliased pointer
- **Training (`gpu/train.c`)**: Increased batch size from 19 to 30
- **transformer submodule**: Updated from `95eb7ba` to `cfd6f45` (includes memory aliasing optimizations from attention and mlp submodules)

**Rationale:**
The `output` buffer is only needed during the forward pass, while `grad_output` is only needed during the backward pass. Since these operations don't overlap, we can safely reuse the same memory region for both. This reduces the memory footprint by one buffer allocation (batch_size × seq_len × d_model floats).

The memory savings from this optimization (combined with similar optimizations in the transformer, attention, and mlp layers) enables us to increase the batch size from 19 to 30, improving training throughput.

**Testing:**
- Verified that the code compiles without warnings
- Ensured no memory leaks by removing the redundant `free()`/`cudaFree()` calls for the aliased pointers