### PR TITLE
Adjust Training Hyperparameters for RMSNorm Integration

### DIFF
--- a/gpu/train.c
+++ b/gpu/train.c
@@ -14,7 +14,7 @@ void handle_sigint(int signum) {
         char filename[64];
         time_t now = time(NULL);
         strftime(filename, sizeof(filename), "%Y%m%d_%H%M%S_gpt.bin", localtime(&now));
-        //save_gpt(gpt, filename);
+        save_gpt(gpt, filename);
     }
     exit(128 + signum);
 }

--- a/gpu/train.c
+++ b/gpu/train.c
@@ -14,7 +14,7 @@ void handle_sigint(int signum) {
         char filename[64];
         time_t now = time(NULL);
         strftime(filename, sizeof(filename), "%Y%m%d_%H%M%S_gpt.bin", localtime(&now));
-        save_gpt(gpt, filename);
+        //save_gpt(gpt, filename);
     }
     exit(128 + signum);
 }
@@ -96,10 +96,10 @@ int main(int argc, char* argv[]) {
     // Model hyperparameters
     const int seq_len = 512;
     const int num_layers = 16;
-    const int batch_size = 30;
+    const int batch_size = 26;
     const int d_model = num_layers * 64;
     const int hidden_dim = d_model * 4;
-    const float learning_rate = 0.00004f;
+    const float learning_rate = 0.0001f;
     
     // Initialize or load model
     if (argc > 1) {

--- a/gpu/train.c
+++ b/gpu/train.c
@@ -96,7 +96,7 @@ int main(int argc, char* argv[]) {
     // Model hyperparameters
     const int seq_len = 512;
     const int num_layers = 16;
-    const int batch_size = 26;
+    const int batch_size = 27;
     const int d_model = num_layers * 64;
     const int hidden_dim = d_model * 4;
     const float learning_rate = 0.0001f;

--- a/train.c
+++ b/train.c
@@ -92,7 +92,7 @@ int main(int argc, char* argv[]) {
     const int batch_size = 16;
     const int d_model = num_layers * 64;
     const int hidden_dim = d_model * 4;
-    const float learning_rate = 0.00004f;
+    const float learning_rate = 0.0001f;
     
     // Initialize or load model
     if (argc > 1) {


### PR DESCRIPTION
This PR adjusts training hyperparameters to optimize training with the newly integrated RMSNorm pre-normalization layers.

### Changes

**Learning Rate Adjustment:**
- Increased learning rate from `0.00004` to `0.0001` (2.5x increase) for both CPU and GPU training
- RMSNorm provides more stable gradients, allowing for more aggressive learning rates
- This is consistent with findings in modern transformer architectures (LLaMA, GPT-3) where pre-normalization enables higher learning rates

**GPU Batch Size Adjustment:**
- Reduced GPU batch size from `30` to `27`
- Accounts for additional memory overhead from RMSNorm buffers (`norm_attn_inputs` and `norm_mlp_inputs`)
- Maintains efficient GPU memory utilization

**Submodule Update:**
- Updates transformer submodule to commit `4a4a49b` which includes the RMSNorm implementation

### Rationale

Pre-normalization architectures like the one now implemented benefit from:
1. **Higher learning rates**: Gradients are better conditioned through normalization
2. **More stable training**: RMSNorm prevents activation explosion/vanishing
3. **Faster convergence**: The combination of pre-norm + higher LR typically reduces training time

These hyperparameter adjustments were made to take full advantage of the improved gradient flow provided by RMSNorm.