### PR TITLE
Reduce batch size from 32 to 22 for GPU training

### DIFF
--- a/gpu/train.c
+++ b/gpu/train.c
@@ -104,7 +104,7 @@ int main(int argc, char* argv[]) {
     // Model hyperparameters
     const int seq_len = 512;
     const int num_layers = 21;
-    const int batch_size = 27;
+    const int batch_size = 22;
     const int d_model = num_layers * 64;
     const int hidden_dim = d_model * 4;
     const float learning_rate = 0.0001f;

--- a/gpu/train.c
+++ b/gpu/train.c
@@ -104,7 +104,7 @@ int main(int argc, char* argv[]) {
     // Model hyperparameters
     const int seq_len = 512;
     const int num_layers = 21;
-    const int batch_size = 32;
+    const int batch_size = 27;
     const int d_model = num_layers * 64;
     const int hidden_dim = d_model * 4;
     const float learning_rate = 0.0001f;


### PR DESCRIPTION
This PR adjusts the training batch size for the GPU implementation to better fit memory constraints.

### Changes

**Training Configuration:**
- Reduced `batch_size` from 32 to 22 in `gpu/train.c`
- This change affects GPU training only; CPU training configuration remains unchanged

**Context:**
- Model configuration: 21 layers, d_model=1344 (21*64), hidden_dim=5376 (4x d_model)
- Sequence length: 512 tokens
- With these large model dimensions, reducing batch size helps prevent OOM (Out of Memory) errors during GPU training

**Impact:**
- Lower memory footprint per training step
- Slightly increased training time due to more gradient update steps per epoch
- No changes to model architecture or learning dynamics

**Dependencies:**
- Updated transformer submodule to commit `42cc230` (multi-head attention integration)

### Performance Considerations
The batch size of 22 represents a balance between:
- GPU memory availability (avoiding OOM with FP16/half precision)
- Training efficiency (maintaining reasonable throughput)
- Gradient stability (batch still large enough for stable updates)