### PR TITLE
Fix integer overflow bugs in GPU memory allocation and indexing

### DIFF
--- a/gpu/gpt.c
+++ b/gpu/gpt.c
@@ -22,7 +22,7 @@ GPT* init_gpt(int seq_len, int d_model, int hidden_dim, int num_layers, int batc
     
     size_t token_emb_size = gpt->vocab_size * d_model;
     size_t embedded_size = batch_size * seq_len * d_model;
-    size_t output_size = batch_size * seq_len * gpt->vocab_size;
+    size_t output_size = (size_t)batch_size * seq_len * gpt->vocab_size;
     
     // Allocate host memory for weight initialization
     half* h_token_embedding = (half*)malloc(token_emb_size * sizeof(half));
@@ -214,7 +214,7 @@ __global__ static void softmax_cross_entropy_kernel(float* loss_result, half* gr
     
     if (b >= batch_size || t >= seq_len) return;
     
-    int logits_offset = b * seq_len * vocab_size + t * vocab_size;
+    size_t logits_offset = (size_t)b * seq_len * vocab_size + t * vocab_size;
     half* logits_bt = &logits[logits_offset];
     half* grad_logits_bt = &grad_logits[logits_offset];
     

--- a/gpu/train.c
+++ b/gpu/train.c
@@ -116,7 +116,7 @@ int main(int argc, char* argv[]) {
         gpt = init_gpt(seq_len, d_model, hidden_dim, num_layers, batch_size, cublaslt_handle);
     }
     
-    printf("Parameters: ~%.1fM\n", (float)(gpt->vocab_size * d_model + num_layers * (4 * d_model * d_model + d_model * hidden_dim + hidden_dim * d_model)) / 1e6f);
+    printf("Parameters: ~%.1fM\n", (float)(gpt->vocab_size * d_model + num_layers * ((size_t)4 * d_model * d_model + d_model * hidden_dim + hidden_dim * d_model)) / 1e6f);
     
     // Create shuffled indices for random sampling without replacement
     size_t total_sequences = (get_file_size("../corpus.txt") - 2) / (2 * seq_len);


### PR DESCRIPTION
This PR addresses integer overflow issues that occur when training large models with high vocabulary sizes and batch dimensions.

### Changes

**Memory Allocation Fix (`gpu/gpt.c`):**
```c
// Before: potential overflow when multiplying int values
size_t output_size = batch_size * seq_len * gpt->vocab_size;

// After: explicit size_t cast prevents overflow
size_t output_size = (size_t)batch_size * seq_len * gpt->vocab_size;
```

**Kernel Indexing Fix (`gpu/gpt.c`):**
```c
// Before: int overflow in logits offset calculation
int logits_offset = b * seq_len * vocab_size + t * vocab_size;

// After: size_t for safe 64-bit indexing
size_t logits_offset = (size_t)b * seq_len * vocab_size + t * vocab_size;
```

**Parameter Count Fix (`gpu/train.c`):**
```c
// Before: overflow in parameter calculation
num_layers * (4 * d_model * d_model + ...)

// After: cast to size_t before multiplication
num_layers * ((size_t)4 * d_model * d_model + ...)
```

### Context

The product `batch_size * seq_len * vocab_size` exceeds `INT_MAX` (2,147,483,647) in some intermediate calculations when combined with other multiplications, causing undefined behavior and incorrect memory allocation.

### Impact
- Prevents silent memory corruption and crashes during training
- Ensures correct gradient computation for all batch elements
- Fixes incorrect parameter count reporting in logs